### PR TITLE
Suppress access logs output of the built-in php web-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,7 @@ install:
   - composer require drupal/search_api_solr_multilingual:1.x-dev
   - composer require drupal/facets:1.x-dev
   - composer require drush/drush
-  #########################################
-  # to be removed once #2803701 is resolved
-  - cd modules/search_api
-  - curl https://www.drupal.org/files/issues/2803701-8--php5_strict_warning.patch | patch -p1
   - cd $TRAVIS_BUILD_DIR/../drupal
-  #########################################
 
 before_script:
   # start the built-in php web server (mysql is already started)

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,9 @@ install:
   #########################################
 
 before_script:
-  # start the built-in php web server (mysql is already started)
-  - php -S localhost:8888 &
+  # start the built-in php web server (mysql is already started) and
+  # suppress web-server access logs output.
+  - php -S localhost:8888 >& /dev/null &
   # Install the site
   - ./vendor/bin/drush -v site-install minimal --db-url=mysql://root:@localhost/drupal --yes
   - ./vendor/bin/drush en --yes simpletest


### PR DESCRIPTION
This change suppress the web-server's access logs output and results in a more laconic build output like:

> Drupal\search_api\Tests\CacheabilityTest                      21 passes                            3 messages
> Drupal\search_api\Tests\HooksTest                             59 passes                           15 messages
> Drupal\search_api\Tests\LocalActionsWebTest                   15 passes                            3 messages
> Drupal\search_api\Tests\LanguageIntegrationTest               70 passes                           25 messages
> Drupal\search_api_solr_defaults\Tests\IntegrationTest         99 passes                           33 messages
> Drupal\search_api\Tests\OverviewPageTest                     112 passes                           30 messages
> Drupal\search_api_db\Tests\IntegrationTest                    15 passes                            4 messages
> Drupal\search_api\Tests\ProcessorIntegrationTest             159 passes                           35 messages
> Drupal\search_api_solr\Tests\IntegrationTest                 265 passes                           76 messages
> Drupal\search_api_solr_multilingual\Tests\IntegrationTest    265 passes                           76 messages
> Drupal\search_api_solr\Tests\ViewsTest                       362 passes                           75 messages
> Drupal\search_api_solr_multilingual\Tests\ViewsTest          362 passes                           75 messages
> Drupal\facets\Tests\LanguageIntegrationTest                   32 passes                            7 messages
> Drupal\facets\Tests\FacetSourceTest                           64 passes                           12 messages
> Drupal\search_api_db_defaults\Tests\IntegrationTest          135 passes                           47 messages
> Drupal\facets\Tests\UrlIntegrationTest                       113 passes                           24 messages
> Drupal\core_search_facets\Tests\HooksTest                     19 passes                            5 messages
> Drupal\rest_facets\Tests\RestIntegrationTest                  73 passes                           16 messages
> Drupal\search_api\Tests\ViewsTest                            358 passes                           74 messages
> Drupal\search_api\Tests\IntegrationTest                      932 passes   6 fails                263 messages
> Drupal\facets\Tests\WidgetIntegrationTest                    148 passes                           42 messages
> Drupal\core_search_facets\Tests\IntegrationTest              222 passes   8 fails                 64 messages
> Drupal\facets\Tests\ProcessorIntegrationTest                 432 passes                          120 messages
> Drupal\facets\Tests\IntegrationTest                          824 passes   4 fails                223 messages
