### PR TITLE
Delete block patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ install:
   - cd $TRAVIS_BUILD_DIR/../drupal
 
 before_script:
-  # Start the built-in php web server via Drush (mysql is already started) and
+  # Start the built-in php web server (mysql is already started) and
   # suppress web-server access logs output.
-  - ./vendor/bin/drush rs 8888 >& /dev/null &
+  - php -S localhost:8888 ./vendor/drush/drush/commands/runserver/d8-rs-router.php >& /dev/null &
   # Install the site
   - ./vendor/bin/drush -v site-install minimal --db-url=mysql://root:@localhost/drupal --yes
   - ./vendor/bin/drush en --yes simpletest

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ install:
   - composer require drupal/search_api_solr_multilingual:1.x-dev
   - composer require drupal/facets:1.x-dev
   - composer require drush/drush
+  #########################################
+  # to be removed once #2817399 is resolved
+  - cd modules/facets
+  - curl https://www.drupal.org/files/issues/fix_block_delete_tests-2817399-11.patch | patch -p1
   - cd $TRAVIS_BUILD_DIR/../drupal
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,11 @@ install:
   # to be removed once #2817399 is resolved
   - cd modules/facets
   - curl https://www.drupal.org/files/issues/fix_block_delete_tests-2817399-11.patch | patch -p1
+  #########################################
+  # to be removed once https://github.com/drush-ops/drush/pull/2420 is approved
+  - cd $TRAVIS_BUILD_DIR/../drupal/vendor/drush/drush
+  - curl https://gist.githubusercontent.com/itsekhmistro/30ced918a45de48a3543e6fc5d0d3098/raw/ed2da17268507ca12909f0ff684a38fccef7b259/d8-rs-router.fix-q.patch | patch -p1
+  #########################################
   - cd $TRAVIS_BUILD_DIR/../drupal
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ install:
 before_script:
   # Start the built-in php web server via Drush (mysql is already started) and
   # suppress web-server access logs output.
-  - drush rs 8888 >& /dev/null &
+  - ./vendor/bin/drush rs 8888 >& /dev/null &
   # Install the site
   - ./vendor/bin/drush -v site-install minimal --db-url=mysql://root:@localhost/drupal --yes
   - ./vendor/bin/drush en --yes simpletest

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,9 @@ install:
   - cd $TRAVIS_BUILD_DIR/../drupal
 
 before_script:
-  # Start the built-in php web server (mysql is already started) and
+  # Start the built-in php web server via Drush (mysql is already started) and
   # suppress web-server access logs output.
-  - php -S localhost:8888 >& /dev/null &
+  - drush rs 8888 >& /dev/null &
   # Install the site
   - ./vendor/bin/drush -v site-install minimal --db-url=mysql://root:@localhost/drupal --yes
   - ./vendor/bin/drush en --yes simpletest


### PR DESCRIPTION
There are 2 patches applied in this pull request.
1. Facets patch to correctly remove(delete) Facets block.
2. Drush patch that prevents modifications of Current URL on built-in webserver, and allows to pass assertUrl() tests. See https://github.com/drush-ops/drush/pull/2420

Finally all SimplesTests has passed https://travis-ci.org/itsekhmistro/search_api_integration_tests/jobs/171360869
