### PR TITLE
Shallow clone of core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
   - echo "error_log=syslog" >> `php --ini | grep "Loaded Configuration" | awk '{print $4}'`
   # Get latest Drupal 8 core
   - cd $TRAVIS_BUILD_DIR/..
-  - git clone --branch 8.3.x https://git.drupal.org/project/drupal.git
+  - git clone --depth=1 --branch 8.3.x https://git.drupal.org/project/drupal.git
   - cd $TRAVIS_BUILD_DIR/../drupal
   - composer install
   - composer config repositories.drupal composer https://packages.drupal.org/8


### PR DESCRIPTION
Using shallow clones will speed up the `git clone` command and make the tests complete somewhat faster.