### PR TITLE
Remove phantom js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ before_install:
   - composer self-update
   - composer global require "hirak/prestissimo:^0.3"
   - sudo apt-get update -qq > /dev/null
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - "phantomjs --version"
 
 install:
   # Make sure we don't fail when checking out projects
@@ -90,9 +87,7 @@ before_script:
   - ls -lh $SOLR_CONFS
   # Install Solr
   - cat modules/contrib/search_api_solr/travis-solr.sh | bash
-  # start phantomjs with gastonjs
-  - phantomjs --ssl-protocol=any --ignore-ssl-errors=true ../vendor/jcalderonzumba/gastonjs/src/Client/main.js 8510 1600 1080 > /tmp/pantomjs.out 2>&1 &
-
+ 
 script:
   # Run the tests
   - cd $TRAVIS_BUILD_DIR/../drupal


### PR DESCRIPTION
PhantomJS is only needed for the javascript tests, and I think that its sufficient to run those on drupal.org, they are only used in facets.

Since we're running into the time limits, I think removing this should be a good idea. See https://travis-ci.org/mkalkbrenner/search_api_integration_tests/jobs/221257935