### PR TITLE
Speed up tests by requiring in 1 command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,14 +55,7 @@ install:
   - git clone --depth=1 --branch $DRUPAL_CORE_BRANCH https://git.drupal.org/project/drupal.git
   - cd $TRAVIS_BUILD_DIR/../drupal
   - composer install
-  - composer require drupal/search_api:1.x-dev
-  - composer require drupal/search_api_autocomplete:1.x-dev
-  - composer require drupal/search_api_solr:1.x-dev
-  - composer require drupal/search_api_solr_multilingual:1.x-dev
-  - composer require drupal/search_api_location:1.x-dev
-  - composer require drupal/facets:1.x-dev
-  - composer require drupal/geofield:1.x-dev
-  - composer require drush/drush
+  - composer require drush/drush drupal/search_api:1.x-dev drupal/search_api_autocomplete:1.x-dev drupal/search_api_solr:1.x-dev drupal/search_api_solr_multilingual:1.x-dev drupal/search_api_location:1.x-dev drupal/facets:1.x-dev drupal/geofield:1.x-dev
   # Patch template.
   #########################################
   # to be removed once #2824932 is resolved


### PR DESCRIPTION
The tests are slow, the biggest things that slow down the test-run, apart from running the actual tests, is all the time composer needs to calculate/download dependencies. 

Doing all of this in one go, should speed up the tests.

This is especially so for the facets tests on php 5.x, because we have so many integration tests, they frequently time out. Requiring everything in 1 go should save us ~ 45seconds per `composer require`. This pull request should speed up the tests by ~5 minutes. Hopefully that is enough to get all the tests trough on php 5.x